### PR TITLE
feat: upgrade nixpkgs, erlang and elixir

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,6 +7,6 @@ with pkgs;
 buildEnv {
   name = "builder";
   paths = [
-    beam.packages.erlangR25.elixir_1_14
+    beam.packages.erlangR26.elixir_1_15
   ];
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
     "homepage": "",
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "b022369ef2978246c9ac6f558f9eaf61144f2172",
-    "sha256": "1j9ssr8c0x1xv5228z5ky67wbkrvnwj3yjrdd2n81x2319c79a5x",
+    "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+    "sha256": "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k",
     "type": "tarball",
-    "url": "https://github.com/NixOS/nixpkgs/archive/b022369ef2978246c9ac6f558f9eaf61144f2172.tar.gz",
+    "url": "https://github.com/NixOS/nixpkgs/archive/057f9aecfb71c4437d2b27d3323df7f93c010b7e.tar.gz",
     "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -31,8 +31,8 @@ let
     export MIX_HOME=$PWD/.nix-mix
     export HEX_HOME=$PWD/.nix-hex
 
-    export MIX_PATH="${beam.packages.erlangR25.hex}/lib/erlang/lib/hex/ebin"
-    export PATH=${erlangR25}/bin:$MIX_HOME/bin:$HEX_HOME/bin:$MIX_HOME/escripts:bin:$PATH
+    export MIX_PATH="${beam.packages.erlangR26.hex}/lib/erlang/lib/hex/ebin"
+    export PATH=${erlangR26}/bin:$MIX_HOME/bin:$HEX_HOME/bin:$MIX_HOME/escripts:bin:$PATH
 
     export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
FIX:
`** (Mix) You're trying to run :livebook on Elixir v1.14.2 but it has declared in its mix.exs file it supports only Elixir ~> 1.15.2`